### PR TITLE
Add environment variables to change max file sizes

### DIFF
--- a/examples/single-api/docker-compose.yml
+++ b/examples/single-api/docker-compose.yml
@@ -27,6 +27,21 @@ services:
       DATABASE_PASSWORD: "somepassword"
       ADMIN_EMAIL: "admin@localhost.com"
       ADMIN_PASSWORD: "directusrocks"
+
+      # The following settings are useful, if you want to change the file size limit of directus. 
+      # If you don't want to set these values here but rather mount a php.ini file, just delete those variables.
+      # The values below are the default settings.
+
+      # Nginx settings
+      CLIENT_MAX_BODY_SIZE: 100M
+
+      # php settings
+      UPLOAD_MAX_FILESIZE: 2M
+      POST_MAX_SIZE: 8M
+      MEMORY_LIMIT: 128M
+      MAX_INPUT_TIME: 60
+      MAX_EXECUTION_TIME: 30
+
     ports:
       - 7000:80
 

--- a/projects/api/rootfs/etc/services.d/nginx/run
+++ b/projects/api/rootfs/etc/services.d/nginx/run
@@ -1,6 +1,15 @@
 #!/usr/bin/with-contenv sh
 set -e;
 
+# Apply some environment variables if they are set
+
+# set nginx client_max_body_size (default is 100M).
+if ! [[ -z "${CLIENT_MAX_BODY_SIZE}" ]]; then
+  sed -i "s/client_max_body_size.*/client_max_body_size ${CLIENT_MAX_BODY_SIZE};/g" /etc/nginx/conf.d/default.conf
+fi
+
+
+
 fpm_is_up() {
     stat /var/run/php7-fpm.sock &> /dev/null
 }

--- a/projects/api/rootfs/etc/services.d/php_fpm/run
+++ b/projects/api/rootfs/etc/services.d/php_fpm/run
@@ -1,5 +1,35 @@
 #!/usr/bin/with-contenv sh
 set -e;
 
+
+# Apply some environment variables if they are set
+
+# set maximum upload file size (default is 2M)
+if ! [[ -z "${UPLOAD_MAX_FILESIZE}" ]]; then
+  sed -i "s/upload_max_filesize =.*/upload_max_filesize = ${UPLOAD_MAX_FILESIZE}/g" /etc/php7/php.ini
+fi
+
+# set maximum post size (default is 8M).
+if ! [[ -z "${POST_MAX_SIZE}" ]]; then
+  sed -i "s/post_max_size =.*/post_max_size = ${POST_MAX_SIZE}/g" /etc/php7/php.ini
+fi
+
+# set memory limit (default is 128M).
+if ! [[ -z "${MEMORY_LIMIT}" ]]; then
+  sed -i "s/memory_limit =.*/memory_limit = ${MEMORY_LIMIT}/g" /etc/php7/php.ini
+fi
+
+# set max_input_time in seconds (default is 60).
+if ! [[ -z "${MAX_INPUT_TIME}" ]]; then
+  sed -i "s/max_input_time =.*/max_input_time = ${MAX_INPUT_TIME}/g" /etc/php7/php.ini
+fi
+
+# set max_execution_time in seconds (default is 30).
+if ! [[ -z "${MAX_EXECUTION_TIME}" ]]; then
+  sed -i "s/max_execution_time =.*/max_execution_time = ${MAX_EXECUTION_TIME}/g" /etc/php7/php.ini
+fi
+
+
+
 # Start PHP-FPM
 exec /usr/sbin/php-fpm7 -R --nodaemonize


### PR DESCRIPTION
This pull request adds some environment variables to easily configure the maximum file size allowed in directus without the need to create a custom docker image just to change that.

Therefore a new entrypoint.sh script (api container) changes some values of php.ini and default.conf on startup depending on the environment variables.