### PR TITLE
Entrypoint.sh file changes according to new config_example.js file

### DIFF
--- a/projects/app/entrypoint.sh
+++ b/projects/app/entrypoint.sh
@@ -30,7 +30,7 @@ ROUTER_BASE_URL=$(echo "${ROUTER_BASE_URL:-/}" | sed 's#/#\\/#g')
 
 # Replace variables
 cat /directus/config.js | \
-sed -e 's#      \"https://demo-api.directus.app/_/\": \"Directus Demo API\"#'$VALUES'#g' | \
+sed -e 's#      \"../_/\": \"Directus Demo API\"#'$VALUES'#g' | \
 sed -e 's/allowOtherAPI: false/allowOtherAPI: '${ALLOW_OTHER_API:-false}'/g' | \
 sed -e 's/routerBaseUrl: "\/"/routerBaseUrl: "'${ROUTER_BASE_URL}'"/g' | \
 sed -e 's/routerMode: "hash"/routerMode: "'${ROUTER_MODE:-hash}'"/g' > /usr/share/nginx/html/config.js


### PR DESCRIPTION
Since version 7.5.0 of the directus app the format for the `config_example.js` file changed from
```javascript
api: {
      "https://demo-api.directus.app/_/": "Directus Demo API"
    },
```
To:
```Javascript
api: {
      "../_/": "Directus Demo API"
    },
```

Because the entrypoint.sh uses sed which uses regex to add environment variables to the config file, it will fail because of the changed format.

This small edit fixes that -> Maybe in the future this should be changed completely