### PR TITLE
mysqli was missing from the Docker file

### DIFF
--- a/images/apache/Dockerfile
+++ b/images/apache/Dockerfile
@@ -18,7 +18,7 @@ RUN \
   rm -rf /var/lib/apt/lists/* && \
   docker-php-ext-configure zip --with-libzip && \
   docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \
-  docker-php-ext-install gd zip exif pdo pdo_mysql xml fileinfo && \
+  docker-php-ext-install gd zip exif pdo pdo_mysql xml fileinfo mysqli && \
   pecl install imagick && pecl install redis && \
   docker-php-ext-enable imagick && docker-php-ext-enable redis
 


### PR DESCRIPTION
When I tried to create a second project on Directus it tells me I am missing mysqli extension.

![image](https://user-images.githubusercontent.com/59620753/72837367-37828f00-3c43-11ea-9f43-a46ddb4192ca.png)
