### PR TITLE
Use docker networks instead of deprecated links

### DIFF
--- a/examples/redis-minio/docker-compose.yaml
+++ b/examples/redis-minio/docker-compose.yaml
@@ -1,26 +1,34 @@
 
 version: "3"
+
+networks:
+  directus:
+
 services:
   redis:
     image: redis
     container_name: cache
     expose:
       - 6379
-   mysql:
-      image: mysql:5.7
-      environment:
-        MYSQL_DATABASE: "directus"
-        MYSQL_USER: "directus"
-        MYSQL_PASSWORD: "directus"
-        MYSQL_ROOT_PASSWORD: "directus"
-      ports:
-        - 3306:3306
+    networks:
+      - directus
+
+  mysql:
+    image: mysql:5.7
+    environment:
+      MYSQL_DATABASE: "directus"
+      MYSQL_USER: "directus"
+      MYSQL_PASSWORD: "directus"
+      MYSQL_ROOT_PASSWORD: "directus"
+    ports:
+      - 3306:3306
+    networks:
+      - directus
+
   api:
     image: directus/directus:v8.2-apache
     ports:
       - "8080:80"
-    links:
-      - redis
     environment:
       DIRECTUS_ENV: "production"
 
@@ -51,3 +59,6 @@ services:
       DIRECTUS_STORAGE_BUCKET: "1122333"
       DIRECTUS_STORAGE_REGION: ""
       DIRECTUS_STORAGE_ENDPOINT: "https://minio.company.private"
+    networks:
+      - directus
+      

--- a/examples/simple-nginx/docker-compose.yaml
+++ b/examples/simple-nginx/docker-compose.yaml
@@ -1,4 +1,8 @@
 version: "3"
+
+networks:
+  directus:
+    
 services:
   #
   # Load balancer to accept requests from app and app on port 80
@@ -10,6 +14,8 @@ services:
       - 80:80
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
+    networks:
+      - directus
 
   #
   # Database
@@ -22,7 +28,9 @@ services:
       MYSQL_PASSWORD: "directus"
       MYSQL_ROOT_PASSWORD: "directus"
     ports:
-      - 3306:3306
+      - 3306:3306    
+    networks:
+      - directus
 
   #
   # Directus instance.
@@ -68,6 +76,6 @@ services:
     volumes:
       - ./data/config:/var/directus/config
       - ./data/uploads:/var/directus/public/uploads
-
-    links:
-      - mysql:mysql
+    
+    networks:
+      - directus

--- a/examples/simple/docker-compose.yaml
+++ b/examples/simple/docker-compose.yaml
@@ -1,4 +1,8 @@
 version: "3"
+
+networks:
+  directus:
+
 services:
   #
   # Database
@@ -12,6 +16,8 @@ services:
       MYSQL_ROOT_PASSWORD: "directus"
     ports:
       - 3306:3306
+    networks:
+      - directus
 
   #
   # Directus instance.
@@ -57,5 +63,5 @@ services:
       - ./data/config:/var/directus/config
       - ./data/uploads:/var/directus/public/uploads
 
-    links:
-      - mysql:mysql
+    networks:
+      - directus


### PR DESCRIPTION
Hi,

This is a small improvement to use docker networks for container communication instead of links which is deprecated and will be removed as specified in Docker documentation: https://docs.docker.com/compose/compose-file/#links#links.